### PR TITLE
Nim CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,12 +145,13 @@ matrix:
       env: TARGET=graphviz VARIETY=2.36
     # ========================================================================
     - os: linux
-      language: nim
-      sudo: true
-      services:
-        - docker
-      before_install:
-        - docker pull nimlang/nim
+      language: c
+      cache: ccache
+      cache:
+        directories:
+        - .cache
+      env: CHANNEL=stable
+      compiler: gcc
       env: TARGET=nim
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,6 +143,12 @@ matrix:
           packages:
             - graphviz
       env: TARGET=graphviz VARIETY=2.36
+    # ========================================================================
+      sudo: true
+      services:
+        - docker
+      before_install:
+        - docker pull nimlang/nim
 
 install:
   - git clone https://github.com/kaitai-io/kaitai_struct_tests tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,8 @@ matrix:
             - graphviz
       env: TARGET=graphviz VARIETY=2.36
     # ========================================================================
-      - os: linux
+    - os: linux
+      language: nim
       sudo: true
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,7 @@ matrix:
             - graphviz
       env: TARGET=graphviz VARIETY=2.36
     # ========================================================================
+      - os: linux
       sudo: true
       services:
         - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ matrix:
         - .cache
       env: CHANNEL=stable
       compiler: gcc
-      env: TARGET=nim
+      env: TARGET=nim PATH=~/.nimble/bin:$PATH
 
 install:
   - git clone https://github.com/kaitai-io/kaitai_struct_tests tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,6 +149,7 @@ matrix:
         - docker
       before_install:
         - docker pull nimlang/nim
+      env: TARGET=nim
 
 install:
   - git clone https://github.com/kaitai-io/kaitai_struct_tests tests

--- a/config
+++ b/config
@@ -6,6 +6,7 @@ CSHARP_RUNTIME_DIR=runtime/csharp
 JAVA_RUNTIME_DIR=runtime/java
 JAVASCRIPT_RUNTIME_DIR=runtime/javascript
 LUA_RUNTIME_DIR=runtime/lua
+NIM_RUNTIME_DIR=runtime/nim
 PERL_RUNTIME_DIR=runtime/perl
 PHP_RUNTIME_DIR=runtime/php
 PYTHON_RUNTIME_DIR=runtime/python

--- a/prepare-nim
+++ b/prepare-nim
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. ./config
+
+docker run nimlang/nim nim --version
+docker run -v "$(pwd):/project" -w /project nimlang/nim sh -c "nimble install -dy && nimble test"

--- a/prepare-nim
+++ b/prepare-nim
@@ -2,5 +2,9 @@
 
 . ./config
 
-docker run nimlang/nim nim --version
-docker run -v "$(pwd):/project" -w /project nimlang/nim sh -c "nimble install -dy && nimble test"
+export CHOOSENIM_NO_ANALYTICS=1
+curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
+sh init.sh -y
+export PATH=~/.nimble/bin:$PATH
+echo "export PATH=~/.nimble/bin:$PATH" >> ~/.profile
+choosenim $CHANNEL

--- a/prepare-nim
+++ b/prepare-nim
@@ -8,3 +8,4 @@ sh init.sh -y
 export PATH=~/.nimble/bin:$PATH
 echo "export PATH=~/.nimble/bin:$PATH" >> ~/.profile
 choosenim $CHANNEL
+exit 0

--- a/prepare-nim
+++ b/prepare-nim
@@ -5,7 +5,3 @@
 export CHOOSENIM_NO_ANALYTICS=1
 curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh
 sh init.sh -y
-export PATH=~/.nimble/bin:$PATH
-echo "export PATH=~/.nimble/bin:$PATH" >> ~/.profile
-choosenim $CHANNEL
-exit 0


### PR DESCRIPTION
Ok this works! I am totally inexperienced with CI so maybe there is a better way to set this up. Sadly travis doesn't support Nim natively, so Nim has to be downloaded and bootstrapped.

Oh, and in order to make it work, we must add [nim runtime](https://github.com/kaitai-io/kaitai_struct_nim_runtime) as a submodule in `kaitai-io/kaitai_struct/runtime` folder.

Some adjustments were needed in the `ci-nim` script, so [this](https://github.com/kaitai-io/kaitai_struct_tests/pull/61) should be merged too.
You could also merge [this](https://github.com/kaitai-io/kaitai_struct_compiler/pull/176) (although not strictly needed for the CI to work now).

And [here](https://github.com/kaitai-io/kaitai_ci_ui/pull/1) is the UI entry.