### PR TITLE
Travis: Move from Node.JS 4, 7 to Node.JS 4, 8, 10, 12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,16 @@ matrix:
       env: TARGET=javascript VARIETY=nodejs4
     - os: linux
       language: node_js
-      node_js: 7
-      env: TARGET=javascript VARIETY=nodejs7
+      node_js: 8
+      env: TARGET=javascript VARIETY=nodejs8
+    - os: linux
+      language: node_js
+      node_js: 10
+      env: TARGET=javascript VARIETY=nodejs10
+    - os: linux
+      language: node_js
+      node_js: 12
+      env: TARGET=javascript VARIETY=nodejs12
     # ========================================================================
     - os: linux
       language: perl


### PR DESCRIPTION
Node.JS 4 and 7 are very old and have not been updated in many years. These Node versions are the current active LTS versions and should be very safe targets until they reach EOL (which is not for at least a year for either.)

Fixes https://github.com/kaitai-io/kaitai_struct/issues/729.