### PR TITLE
Update Python CI to Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,8 +119,8 @@ matrix:
     - os: linux
       dist: bionic
       language: python
-      python: 3.8
-      env: TARGET=python VARIETY=3.8
+      python: 3.9
+      env: TARGET=python VARIETY=3.9
     # ========================================================================
     - os: linux
       language: python
@@ -133,8 +133,8 @@ matrix:
     - os: linux
       dist: bionic
       language: python
-      python: 3.8
-      env: TARGET=construct VARIETY=python3.8
+      python: 3.9
+      env: TARGET=construct VARIETY=python3.9
     # ========================================================================
     - os: linux
       language: ruby

--- a/prepare-construct
+++ b/prepare-construct
@@ -2,7 +2,4 @@
 
 . ./config
 
-pip install construct
-
-# this package dropped support for Python 2.7 since 3.0.0, so we're using the latest compatible version
-pip install "unittest-xml-reporting~=2.5.2"
+python -m pip install construct unittest-xml-reporting

--- a/prepare-python
+++ b/prepare-python
@@ -4,4 +4,4 @@
 
 git clone https://github.com/kaitai-io/kaitai_struct_python_runtime "$PYTHON_RUNTIME_DIR"
 
-pip install enum34 unittest-xml-reporting
+python -m pip install enum34 unittest-xml-reporting

--- a/prepare-python
+++ b/prepare-python
@@ -4,6 +4,4 @@
 
 git clone https://github.com/kaitai-io/kaitai_struct_python_runtime "$PYTHON_RUNTIME_DIR"
 
-pip install enum34
-
-pip install unittest-xml-reporting
+pip install enum34 unittest-xml-reporting

--- a/prepare-python
+++ b/prepare-python
@@ -6,5 +6,4 @@ git clone https://github.com/kaitai-io/kaitai_struct_python_runtime "$PYTHON_RUN
 
 pip install enum34
 
-# this package dropped support for Python 2.7 since 3.0.0, so we're using the latest compatible version
-pip install "unittest-xml-reporting~=2.5.2"
+pip install unittest-xml-reporting


### PR DESCRIPTION
As well as some small improvements/simplifications to the prepare-python script.

I assume this will also need an update in https://github.com/kaitai-io/kaitai_ci_ui so that the results for Python 3.9 are displayed correctly?