### PR TITLE
Migrate java support from Travis to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         tsv:
-#          - target: csharp
-#            subtarget: ''
-#            variety: netcore2.2.103_linux
-#            dotnet: 2.2.103
+          - target: csharp
+            subtarget: ''
+            variety: netcore2.2.103_linux
+            dotnet: 2.2.103
           - target: csharp
             subtarget: ''
             variety: netcore3.0.100_linux

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request: {}
 
 jobs:
   test:
@@ -11,14 +12,30 @@ jobs:
     strategy:
       matrix:
         tsv:
-          - target: csharp
-            subtarget: ''
-            variety: netcore2.2.103_linux
-            dotnet: 2.2.103
+#          - target: csharp
+#            subtarget: ''
+#            variety: netcore2.2.103_linux
+#            dotnet: 2.2.103
           - target: csharp
             subtarget: ''
             variety: netcore3.0.100_linux
             dotnet: 3.0.100
+          - target: java
+            subtarget: ''
+            variety: temurin8
+            java_distribution: temurin
+            java_version: 8
+          - target: java
+            subtarget: ''
+            variety: temurin11
+            java_distribution: temurin
+            java_version: 11
+          - target: java
+            subtarget: ''
+            variety: temurin17
+            java_distribution: temurin
+            java_version: 17
+
     steps:
       - name: Dump matrix context
         env:
@@ -37,6 +54,12 @@ jobs:
       - uses: nuget/setup-nuget@v1
         with:
           nuget-version: '5.x'
+        if: matrix.tsv.dotnet
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{matrix.tsv.java_distribution}}
+          java-version: ${{matrix.tsv.java_version}}
+        if: matrix.tsv.java_distribution
       - name: GitHub Actions job_id parser
         uses: Tiryoh/gha-jobid-action@v0.1.0
         id: job_info

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,36 +54,6 @@ matrix:
       # no apt-get for osx :(
       env: TARGET=cpp_stl SUBTARGET=_11 VARIETY=clang7.3_osx
     # ========================================================================
-    # Disabled: our runtime now uses java.nio extensively => JDK7+ only
-#   - os: linux
-#     language: java
-#     jdk: openjdk6
-#     env: TARGET=java
-    - os: linux
-      dist: trusty
-      language: java
-      jdk: openjdk7
-      env: TARGET=java VARIETY=openjdk7
-    - os: linux
-      dist: trusty
-      language: java
-      addons:
-        apt:
-          packages:
-            - oracle-java8-installer
-      jdk: oraclejdk8
-      env: TARGET=java VARIETY=oraclejdk8
-    - os: linux
-      dist: bionic
-      language: java
-      jdk: openjdk11
-      env: TARGET=java VARIETY=openjdk11
-    - os: linux
-      dist: bionic
-      language: java
-      jdk: openjdk17
-      env: TARGET=java VARIETY=openjdk17
-    # ========================================================================
     - os: linux
       language: node_js
       node_js: 4


### PR DESCRIPTION
* Adds Java CI based on GitHub Actions, following the suit of the rest of the implementations.
* Remove legacy Java CI based on Travis.