### PR TITLE
Migrate macOS C++ builds from Travis to GH Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,3 +64,209 @@ jobs:
             -m "Build results of ${GITHUB_REF#refs/heads/*} kaitai-io/ci_targets@$GITHUB_SHA" \
             -b "${TARGET}${SUBTARGET}"/"$IMPL-macos-x86_64" \
             -- --exclude=.git --exclude=.travis.yml tests/test_out
+
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tsv:
+          - target: csharp
+            implementation: netcore2.2.103
+            dotnet: 2.2.103
+          - target: csharp
+            implementation: netcore3.0.100
+            dotnet: 3.0.100
+    env:
+      TARGET: ${{matrix.tsv.target}}
+      SUBTARGET: ${{matrix.tsv.subtarget}}
+      IMPL: ${{matrix.tsv.implementation}}
+    steps:
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{matrix.tsv.dotnet}}
+        if: matrix.tsv.dotnet
+      - uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: '5.x'
+        if: matrix.tsv.dotnet
+      - name: GitHub Actions job_id parser
+        uses: Tiryoh/gha-jobid-action@v0.1.2
+        id: job_info
+        with:
+          github_token: ${{github.token}}
+          job_name: ${{ format('{0} ({1}, {2}, {3})', github.job, matrix.tsv.target, matrix.tsv.variety, matrix.tsv.dotnet) }}
+      - name: prepare
+        run: |
+          git clone https://github.com/kaitai-io/kaitai_struct_tests tests
+          ln -s ../compiled tests/compiled
+          ./prepare-$TARGET
+      - name: run
+        env:
+          GH_JOB_ID: ${{steps.job_info.outputs.job_id}}
+          GH_HTML_URL: ${{steps.job_info.outputs.html_url}}
+        run: |
+          cd tests
+          ./ci-$TARGET
+          cd ..
+      - name: publish
+        env:
+          BOT_SSH_KEY: ${{secrets.BOT_SSH_KEY}}
+        run: |
+          ./push_artifacts/git_config_kaitai_bot
+          ./push_artifacts/publish \
+            -o kaitai-io \
+            -r ci_artifacts \
+            -m "Build results of ${GITHUB_REF#refs/heads/*} kaitai-io/ci_targets@$GITHUB_SHA" \
+            -b "${TARGET}${SUBTARGET}"/"$IMPL-linux-x86_64" \
+            -- --exclude=.git --exclude=.travis.yml tests/test_out
+
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tsv:
+          - target: cpp_stl
+            subtarget: _98
+            implementation: clang3.4
+          - target: cpp_stl
+            subtarget: _11
+            implementation: clang3.4
+          - target: cpp_stl
+            subtarget: _98
+            implementation: clang11
+          - target: cpp_stl
+            subtarget: _11
+            implementation: clang11
+          - target: cpp_stl
+            subtarget: _98
+            implementation: gcc4.8
+          - target: cpp_stl
+            subtarget: _11
+            implementation: gcc4.8
+          - target: cpp_stl
+            subtarget: _98
+            implementation: gcc11
+#          - target: cpp_stl
+#            subtarget: _11
+#            implementation: gcc11
+          - target: construct
+            implementation: python2.7
+          - target: construct
+            implementation: python3.4
+          - target: construct
+            implementation: python3.11
+          - target: go
+            implementation: 1.19
+          - target: java
+            implementation: zulu7
+          - target: java
+            implementation: temurin8
+          - target: java
+            implementation: temurin11
+          - target: java
+            implementation: temurin17
+          - target: javascript
+            implementation: nodejs4
+          - target: javascript
+            implementation: nodejs8
+          - target: javascript
+            implementation: nodejs10
+          - target: javascript
+            implementation: nodejs12
+          - target: javascript
+            implementation: nodejs18
+          - target: lua
+            implementation: 5.3
+          - target: nim
+            implementation: 1.6.0
+          - target: perl
+            implementation: 5.24
+          - target: perl
+            implementation: 5.38
+          - target: php
+            implementation: 7.1
+          - target: php
+            implementation: 8.2
+          - target: python
+            implementation: 2.7
+          - target: python
+            implementation: 3.4
+          - target: python
+            implementation: 3.11
+          - target: ruby
+            implementation: 1.9
+          - target: ruby
+            implementation: 2.3
+          - target: ruby
+            implementation: 3.2
+    env:
+      TARGET: ${{matrix.tsv.target}}
+      SUBTARGET: ${{matrix.tsv.subtarget}}
+      IMPL: ${{matrix.tsv.implementation}}
+    steps:
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: docker pull
+        run: |
+          docker pull ghcr.io/kaitai-io/kaitai-"$TARGET"-"$IMPL"-linux-x86_64
+      - name: download tests
+        run: |
+          git clone https://github.com/kaitai-io/kaitai_struct_tests tests
+          cp -r compiled tests/compiled
+      - name: download runtime
+        run: |
+          mkdir -p runtime
+          git clone https://github.com/kaitai-io/kaitai_struct_${{matrix.tsv.target}}_runtime runtime/${{matrix.tsv.target}}
+        if: matrix.tsv.target != 'construct'
+
+      # Two different job_id parsers: for 3 values (with subtarget being non-empty) and for 2 values (with subtarget being empty)
+      - name: job_id parser 3
+        uses: Tiryoh/gha-jobid-action@v0.1.2
+        id: job_info3
+        with:
+          github_token: ${{github.token}}
+          job_name: ${{ format('{0} ({1}, {2}, {3})', github.job, matrix.tsv.target, matrix.tsv.subtarget, matrix.tsv.implementation) }}
+        if: matrix.tsv.subtarget != ''
+      - name: job_id parser 2
+        uses: Tiryoh/gha-jobid-action@v0.1.2
+        id: job_info2
+        with:
+          github_token: ${{github.token}}
+          job_name: ${{ format('{0} ({1}, {2})', github.job, matrix.tsv.target, matrix.tsv.implementation) }}
+        if: matrix.tsv.subtarget == ''
+
+      - name: run tests
+        env:
+          GH_JOB_ID: ${{steps.job_info3.outputs.job_id || steps.job_info2.outputs.job_id}}
+          GH_HTML_URL: ${{steps.job_info3.outputs.html_url || steps.job_info2.outputs.html_url}}
+        run: |
+          cd tests
+          ./docker-ci -t "$TARGET" -u "$SUBTARGET" -i "$IMPL"
+      # - name: publish as artifact
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: test-${{matrix.tsv.target}}${{matrix.tsv.subtarget}}-${{matrix.tsv.implementation}}
+      #     path: tests/test_out
+      - name: publish
+        env:
+          BOT_SSH_KEY: ${{secrets.BOT_SSH_KEY}}
+        run: |
+          ./push_artifacts/git_config_kaitai_bot
+          ./push_artifacts/publish \
+            -o kaitai-io \
+            -r ci_artifacts \
+            -m "Build results of ${GITHUB_REF#refs/heads/*} kaitai-io/ci_targets@$GITHUB_SHA" \
+            -b "${TARGET}${SUBTARGET}"/"$IMPL-linux-x86_64" \
+            -- --exclude=.git --exclude=.travis.yml tests/test_out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,5 +56,5 @@ jobs:
             -o kaitai-io \
             -r ci_artifacts \
             -m "Build results of ${GITHUB_REF#refs/heads/*} kaitai-io/ci_targets@$GITHUB_SHA" \
-            -b "${TARGET}${SUBTARGET}"/"$IMPL-linux-x86_64" \
+            -b "${TARGET}${SUBTARGET}"/"$IMPL-macos-x86_64" \
             -- --exclude=.git --exclude=.travis.yml tests/test_out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,14 +36,23 @@ jobs:
           git clone https://github.com/kaitai-io/kaitai_struct_tests tests
           ln -s ../compiled tests/compiled
           ./prepare-$TARGET
+
+      # Ideally, we'd like to get URL for GH Action down to job ID level,
+      # and for that we could use Tiryoh/gha-jobid-action@v0.1.2. However,
+      # as of v0.1.2, it's a Docker-based action, so it won't run on anything
+      # but Linux. The way forward is to rewrite it to be JavaScript-based
+      # (see https://github.com/Tiryoh/gha-jobid-action/issues/10), but until
+      # this is resolved, we have no GH_JOB_ID, and we approximate GH_HTML_URL
+      # down to RUN_ID level.
       - name: run
         env:
           GH_JOB_ID: unknown
-          GH_HTML_URL: unknown
         run: |
+          export GH_HTML_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "GH_HTML_URL=$GH_HTML_URL"
           cd tests
           ./ci-$TARGET$SUBTARGET
-          cd ..
+
       - name: publish
         env:
           BOT_SSH_KEY: ${{secrets.BOT_SSH_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,17 +7,18 @@ on:
   pull_request: {}
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  macos:
+    runs-on: macos-12
+    # NB: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
     strategy:
       matrix:
         tsv:
-          - target: csharp
-            implementation: netcore2.2.103
-            dotnet: 2.2.103
-          - target: csharp
-            implementation: netcore3.0.100
-            dotnet: 3.0.100
+          - target: cpp_stl
+            subtarget: _98
+            implementation: clang14
+          - target: cpp_stl
+            subtarget: _11
+            implementation: clang14
     env:
       TARGET: ${{matrix.tsv.target}}
       SUBTARGET: ${{matrix.tsv.subtarget}}
@@ -33,20 +34,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
-      - uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: ${{matrix.tsv.dotnet}}
-        if: matrix.tsv.dotnet
-      - uses: nuget/setup-nuget@v1
-        with:
-          nuget-version: '5.x'
-        if: matrix.tsv.dotnet
-      - name: GitHub Actions job_id parser
-        uses: Tiryoh/gha-jobid-action@v0.1.2
-        id: job_info
-        with:
-          github_token: ${{github.token}}
-          job_name: ${{ format('{0} ({1}, {2}, {3})', github.job, matrix.tsv.target, matrix.tsv.variety, matrix.tsv.dotnet) }}
       - name: prepare
         run: |
           git clone https://github.com/kaitai-io/kaitai_struct_tests tests
@@ -54,156 +41,12 @@ jobs:
           ./prepare-$TARGET
       - name: run
         env:
-          GH_JOB_ID: ${{steps.job_info.outputs.job_id}}
-          GH_HTML_URL: ${{steps.job_info.outputs.html_url}}
+          GH_JOB_ID: unknown
+          GH_HTML_URL: unknown
         run: |
           cd tests
-          ./ci-$TARGET
+          ./ci-$TARGET$SUBTARGET
           cd ..
-      - name: publish
-        env:
-          BOT_SSH_KEY: ${{secrets.BOT_SSH_KEY}}
-        run: |
-          ./push_artifacts/git_config_kaitai_bot
-          ./push_artifacts/publish \
-            -o kaitai-io \
-            -r ci_artifacts \
-            -m "Build results of ${GITHUB_REF#refs/heads/*} kaitai-io/ci_targets@$GITHUB_SHA" \
-            -b "${TARGET}${SUBTARGET}"/"$IMPL-linux-x86_64" \
-            -- --exclude=.git --exclude=.travis.yml tests/test_out
-
-  docker:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tsv:
-          - target: cpp_stl
-            subtarget: _98
-            implementation: clang3.4
-          - target: cpp_stl
-            subtarget: _11
-            implementation: clang3.4
-          - target: cpp_stl
-            subtarget: _98
-            implementation: clang11
-          - target: cpp_stl
-            subtarget: _11
-            implementation: clang11
-          - target: cpp_stl
-            subtarget: _98
-            implementation: gcc4.8
-          - target: cpp_stl
-            subtarget: _11
-            implementation: gcc4.8
-          - target: cpp_stl
-            subtarget: _98
-            implementation: gcc11
-#          - target: cpp_stl
-#            subtarget: _11
-#            implementation: gcc11
-          - target: construct
-            implementation: python2.7
-          - target: construct
-            implementation: python3.4
-          - target: construct
-            implementation: python3.11
-          - target: go
-            implementation: 1.19
-          - target: java
-            implementation: zulu7
-          - target: java
-            implementation: temurin8
-          - target: java
-            implementation: temurin11
-          - target: java
-            implementation: temurin17
-          - target: javascript
-            implementation: nodejs4
-          - target: javascript
-            implementation: nodejs8
-          - target: javascript
-            implementation: nodejs10
-          - target: javascript
-            implementation: nodejs12
-          - target: javascript
-            implementation: nodejs18
-          - target: lua
-            implementation: 5.3
-          - target: nim
-            implementation: 1.6.0
-          - target: perl
-            implementation: 5.24
-          - target: perl
-            implementation: 5.38
-          - target: php
-            implementation: 7.1
-          - target: php
-            implementation: 8.2
-          - target: python
-            implementation: 2.7
-          - target: python
-            implementation: 3.4
-          - target: python
-            implementation: 3.11
-          - target: ruby
-            implementation: 1.9
-          - target: ruby
-            implementation: 2.3
-          - target: ruby
-            implementation: 3.2
-    env:
-      TARGET: ${{matrix.tsv.target}}
-      SUBTARGET: ${{matrix.tsv.subtarget}}
-      IMPL: ${{matrix.tsv.implementation}}
-    steps:
-      - name: Dump matrix context
-        env:
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        run: echo "$MATRIX_CONTEXT"
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'true'
-      - name: docker pull
-        run: |
-          docker pull ghcr.io/kaitai-io/kaitai-"$TARGET"-"$IMPL"-linux-x86_64
-      - name: download tests
-        run: |
-          git clone https://github.com/kaitai-io/kaitai_struct_tests tests
-          cp -r compiled tests/compiled
-      - name: download runtime
-        run: |
-          mkdir -p runtime
-          git clone https://github.com/kaitai-io/kaitai_struct_${{matrix.tsv.target}}_runtime runtime/${{matrix.tsv.target}}
-        if: matrix.tsv.target != 'construct'
-
-      # Two different job_id parsers: for 3 values (with subtarget being non-empty) and for 2 values (with subtarget being empty)
-      - name: job_id parser 3
-        uses: Tiryoh/gha-jobid-action@v0.1.2
-        id: job_info3
-        with:
-          github_token: ${{github.token}}
-          job_name: ${{ format('{0} ({1}, {2}, {3})', github.job, matrix.tsv.target, matrix.tsv.subtarget, matrix.tsv.implementation) }}
-        if: matrix.tsv.subtarget != ''
-      - name: job_id parser 2
-        uses: Tiryoh/gha-jobid-action@v0.1.2
-        id: job_info2
-        with:
-          github_token: ${{github.token}}
-          job_name: ${{ format('{0} ({1}, {2})', github.job, matrix.tsv.target, matrix.tsv.implementation) }}
-        if: matrix.tsv.subtarget == ''
-
-      - name: run tests
-        env:
-          GH_JOB_ID: ${{steps.job_info3.outputs.job_id || steps.job_info2.outputs.job_id}}
-          GH_HTML_URL: ${{steps.job_info3.outputs.html_url || steps.job_info2.outputs.html_url}}
-        run: |
-          cd tests
-          ./docker-ci -t "$TARGET" -u "$SUBTARGET" -i "$IMPL"
-      # - name: publish as artifact
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: test-${{matrix.tsv.target}}${{matrix.tsv.subtarget}}-${{matrix.tsv.implementation}}
-      #     path: tests/test_out
       - name: publish
         env:
           BOT_SSH_KEY: ${{secrets.BOT_SSH_KEY}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
       - name: prepare
         run: |
           git clone https://github.com/kaitai-io/kaitai_struct_tests tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,6 @@ dist: xenial
 matrix:
   include:
     # ========================================================================
-    # C++
-    # C++98
-    - os: osx
-      language: cpp
-      compiler: clang
-      # no apt-get for osx :(
-      env: TARGET=cpp_stl SUBTARGET=_98 VARIETY=clang7.3_osx
-    # ------------------------------------------------------------------------
-    # C++11
-    - os: osx
-      language: cpp
-      compiler: clang
-      # no apt-get for osx :(
-      env: TARGET=cpp_stl SUBTARGET=_11 VARIETY=clang7.3_osx
-    # ========================================================================
     - os: linux
       language: rust
       rust: "1.31.1"

--- a/prepare-cpp_stl
+++ b/prepare-cpp_stl
@@ -8,3 +8,8 @@ git clone https://github.com/kaitai-io/kaitai_struct_cpp_stl_runtime "$CPP_STL_R
 if [ -n "$APPVEYOR" ]; then
 	vcpkg install boost-test:$ARCH-windows zlib:$ARCH-windows libiconv:$ARCH-windows
 fi
+
+# On GitHub Actions for macOS, install prereqs from brew
+if [ -n "$GITHUB_ACTIONS" ] && [ "$RUNNER_OS" = macOS ]; then
+	brew install boost
+fi

--- a/prepare-cpp_stl
+++ b/prepare-cpp_stl
@@ -13,5 +13,5 @@ fi
 if [ -n "$GITHUB_ACTIONS" ] && [ "$RUNNER_OS" = macOS ]; then
 	brew install \
 		boost \
-		gmake
+		make
 fi

--- a/prepare-cpp_stl
+++ b/prepare-cpp_stl
@@ -11,5 +11,7 @@ fi
 
 # On GitHub Actions for macOS, install prereqs from brew
 if [ -n "$GITHUB_ACTIONS" ] && [ "$RUNNER_OS" = macOS ]; then
-	brew install boost
+	brew install \
+		boost \
+		gmake
 fi


### PR DESCRIPTION
Relatively straightforward conversion. Sadly, macOS does not support Docker containers or anything similar, and, moreover, compilers and parts of the toolset are partially binary-only (you can't legally redistribute Xcode), so the only option is to use GitHub Actions native runners.

One caveat which came during these attempts is that at least macOS builds seems to be prone to randomly jumbling multiple lines coming from `make -j` invocation, which, under the hood, invokes multiple compilers emitting their lines in parallel, see [run 5611725493, attempt 1](https://github.com/kaitai-io/ci_targets/actions/runs/5611725493/attempts/1?pr=12).

Investigating the issue, it turned out that:

* In theory, `make` should do line buffering to avoid such problems. In practice, it clearly does not on macOS. 
* macOS runs GNU Make 3.81, which is ancient Make from 2004, last one with GPL2 before GPL3 switch
* Modern GNU Make 4.0+ has option `--output-sync` to control buffering output from individual compiler invocations, even in more meaningful fashion — to ensure that consequential lines from same compiler do not get mixed with another compiler running at the same time, so it makes even more sense to use it in our case.
* We can invoke `cmake --build` rather than `make` directly — in theory, it can also influence buffering.

So far I've implemented [tooling version detection and invoking make with `--output-sync` if GNU Make 4+ is detected](https://github.com/kaitai-io/kaitai_struct_tests/commit/0c8208196305ae020f12df435dd662992c36a1ab).

Alternative approaches I'd like to explore in future, if the problem will still appear, are:

* Installing GNU Make 4+ on macOS
* Ditching make and using ninja altogether